### PR TITLE
feat: add full Docker support for API and MySQL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM eclipse-temurin:21-jdk-alpine
+
+# Set work directory
+WORKDIR /app
+
+# Copy everything
+COPY . .
+
+# Build the application
+RUN ./mvnw clean package -DskipTests
+
+# Expose port
+EXPOSE 8080
+
+# Run the jar
+CMD ["java", "-jar", "target/golfclub-api-0.0.1-SNAPSHOT.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3.8'
+services:
+  mysql:
+    image: mysql:8
+    container_name: golfclub-mysql
+    environment:
+      MYSQL_DATABASE: golf_club_api
+      MYSQL_ROOT_PASSWORD: fiqkir^.
+    ports:
+      - "3307:3306"
+    volumes:
+      - db_data:/var/lib/mysql
+    networks:
+      - golfclub-net
+
+  api:
+    build: .
+    container_name: golfclub-api
+    depends_on:
+      - mysql
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://golfclub-mysql:3306/golf_club_api
+      SPRING_DATASOURCE_USERNAME: root
+      SPRING_DATASOURCE_PASSWORD: fiqkir^.
+    ports:
+      - "8080:8080"
+    networks:
+      - golfclub-net
+
+volumes:
+  db_data:
+
+networks:
+  golfclub-net:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,11 +1,13 @@
 # Database connection
-spring.datasource.url=jdbc:mysql://localhost:3306/golf_club_api
+spring.datasource.url=jdbc:mysql://localhost:3307/golf_club_api
 spring.datasource.username=root
 spring.datasource.password=fiqkir^.
 
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+logging.level.org.springframework=INFO
 
 # JPA settings
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+


### PR DESCRIPTION
Added Dockerfile and docker-compose.yml to containerize the Spring Boot API and MySQL database. Configured networking, volume persistence, and environment variables. API and DB now connect successfully when running via Docker.
